### PR TITLE
Remove Singleton decorator order check

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run clean && npm run compile && npm run cover",
     "clean": "rimraf ./compiled && rimraf ./dist",
     "compile": "ngc -p ./tsconfig.json && tsc -p ./tsconfig.json",
-    "cover": "ts-node node_modules/istanbul/lib/cli.js cover --config .istanbulrc.json _mocha -- --opts ./.mocharc \"src/**/*.spec.ts\"",
+    "cover": "ts-node node_modules/istanbul/lib/cli.js cover --config .istanbulrc.json node_modules/mocha/bin/_mocha -- --opts ./.mocharc \"src/**/*.spec.ts\"",
     "test": "mocha --opts ./.mocharc \"src/**/*.spec.ts\""
   },
   "author": "Craig Spence <craig@trademe.co.nz>",

--- a/src/singleton/singleton.spec.ts
+++ b/src/singleton/singleton.spec.ts
@@ -33,22 +33,6 @@ describe('@Singleton', () => {
         expect(Service.prototype.toString()).to.equal('ServiceSingleton');
     });
 
-    it('should not decorate service if singleton is added after injectable', () => {
-        expect(() => {
-            @Injectable()
-            @Singleton()
-            class Service { }
-
-            let service = new Service();
-        }).to.throw(new EnsureError(`
-            @Singleton must appear before @Injectable:
-
-                @Singleton()
-                @Injectable()
-                export class Service { }
-        `).message);
-    });
-
     it('should still create an instance of the service', () => {
         @Singleton()
         @Injectable()

--- a/src/singleton/singleton.ts
+++ b/src/singleton/singleton.ts
@@ -13,27 +13,10 @@ export function Singleton (): (injectable: any) => any {
     };
 }
 
-// @Singleton must appear before the @Injectable decorator on the class.
-// This is so the service injection is applied to the original class.
-function checkInjectable (injectable): void {
-    let annotations = Reflect.getOwnMetadata('annotations', injectable);
-    let isInjectable = annotations && annotations.some(ann => ann.constructor === Injectable);
-    if (!isInjectable) {
-        throw new EnsureError(`
-            @Singleton must appear before @Injectable:
-
-                @Singleton()
-                @Injectable()
-                export class ${injectable.name} { }
-        `);
-    }
-}
-
 function createSingleton (injectable): Function {
     let instantiated: boolean = null;
     return function singleton () {
         if (!instantiated) {
-            checkInjectable(injectable);
             instantiated = true;
             this._reset = () => instantiated = false;
             return injectable.apply(this, arguments);


### PR DESCRIPTION
This pr removes the Singletons checkInjectable decorator order check.

On an AoT build the Injectable decorator is removed as part of the compilation step, so this check will no longer work.